### PR TITLE
Fix cookie parsing and generation

### DIFF
--- a/src/protocol/h1/converter.rs
+++ b/src/protocol/h1/converter.rs
@@ -64,8 +64,8 @@ impl<T: AsBuffer> BlockConverter<T> for H1BlockConverter {
                 {
                     if !first {
                         kawa.out.push_back(OutBlock::Store(Store::Static(b"; ")));
-                        first = false;
                     }
+                    first = false;
                     kawa.out.push_back(OutBlock::Store(cookie.key));
                     kawa.out.push_back(OutBlock::Store(Store::Static(b"=")));
                     kawa.out.push_back(OutBlock::Store(cookie.val));

--- a/src/protocol/h1/parser/primitives.rs
+++ b/src/protocol/h1/parser/primitives.rs
@@ -121,7 +121,7 @@ compile_lookup!(vchar => [0x00..0x20, 0x7F..0xFF]);
 
     Visible characters
    SP  !  "  #  $  %  &  '  (  )  *  +  ,  -  .  /
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    ?, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     0  1  2  3  4  5  6  7  8  9  :  ;  <  =  >  ?
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, ?, 1, 1,
     @  A  B  C  D  E  F  G  H  I  J  K  L  M  N  O
@@ -133,10 +133,10 @@ compile_lookup!(vchar => [0x00..0x20, 0x7F..0xFF]);
     p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
 
-    note: cookie values can contain equal signs, not keys. A key can't contain colons.
+    note: cookie values can contain equal signs and spaces, not keys. A key can't contain colons.
 */
 compile_lookup!(ck_char => [0x00..0x20, ';', '=', 0x7F..0xFF]);
-compile_lookup!(cv_char => [0x00..0x20, ';', 0x7F..0xFF]);
+compile_lookup!(cv_char => [0x00..0x1F, ';', 0x7F..0xFF]);
 
 /*
     Creates a achar module for parsing header values and http reasons.

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -21,7 +21,7 @@ Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; foo; ==bar=; 
     req.storage.write(REQ_LONG).expect("write");
     req.blocks.reserve(16);
     req.detached.jar.reserve(16);
-    for _ in 0..20_000_000 {
+    for _ in 0..10_000_000 {
         req.clear();
         req.storage.clear();
         req.storage.fill(REQ_LONG.len());
@@ -45,7 +45,7 @@ Connection: close\r\n\r\n";
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
     req.storage.write(REQ_SHORT).expect("write");
     req.blocks.reserve(16);
-    for _ in 0..20_000_000 {
+    for _ in 0..10_000_000 {
         req.clear();
         req.storage.clear();
         req.storage.fill(REQ_SHORT.len());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -110,11 +110,11 @@ User-Agent: Mozilla/4.0 (compatible; MSIE5.01; Windows NT)\r
 Host: www.tutorialspoint.com\r
 Content-Type: application/x-www-form-urlencoded\r
 Content-Length: 49\r
-Cookie: crumb=1\r
+Cookie: crumb=\"1 2\"\r
 Accept-Language: en-us\r
 Accept-Encoding: gzip, deflate\r
 Connection: Keep-Alive\r
-Cookie: crumb=2; crumb=3\r
+Cookie: crumb=3; crumb=4\r
 \r
 licenseID=string&content=string&/paramsXML=string",
     );


### PR DESCRIPTION
Fix:
- Cookie parsing (spaces are allowed in cookie values)
- Cookie generation (fix separators)
- Force no content-length on 1xx, 204 and 304