### PR TITLE
Fix parse_url, add consumed field to Kawa, fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/CleverCloud/kawa). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/CleverCloud/kawaissues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/CleverCloud/kawa/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)

--- a/src/protocol/h1/parser/mod.rs
+++ b/src/protocol/h1/parser/mod.rs
@@ -52,7 +52,9 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
 
     for block in &mut kawa.blocks {
         if let Block::Header(header) = block {
-            let Store::Slice(key) = &header.key else { unreachable!() };
+            let Store::Slice(key) = &header.key else {
+                unreachable!()
+            };
             let key = key.data(buf);
             if compare_no_case(key, b"host") {
                 // request line has higher priority than Host header


### PR DESCRIPTION
Fix a couple of atrocious URL parsing errors. Add some unittests.
Add "consumed" field to kawa to tell if a kawa message has started transfering. This is important for proxies to know if a request is "safe" to be retried.