### PR TITLE
Fix h1 parse not updating head with expect body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ version = "0.6.3"
 nom = "7.1.3"
 
 [features]
-default = ["simd"]
+default = ["simd", "tolerant-parsing"]
 rc-alloc = []
 custom-vecdeque = []
 simd = []
+tolerant-parsing = []
 
 [profile.release]
 lto = true

--- a/src/protocol/h1/parser/mod.rs
+++ b/src/protocol/h1/parser/mod.rs
@@ -15,8 +15,8 @@ use crate::{
         utils::compare_no_case,
     },
     storage::{
-        AsBuffer, Block, BodySize, Chunk, ChunkHeader, Flags, Kawa, Kind, Pair, ParsingErrorKind,
-        ParsingPhase, StatusLine, Store,
+        AsBuffer, Block, BodySize, Chunk, ChunkHeader, Flags, Kawa, Kind, Pair, ParsingPhase,
+        StatusLine, Store,
     },
 };
 
@@ -27,7 +27,7 @@ fn handle_error<T: AsBuffer>(kawa: &Kawa<T>, error: NomErr<NomError<&[u8]>>) -> 
             let index = kawa.storage.buffer().offset(error.input) as u32;
             ParsingPhase::Error {
                 marker: kawa.parsing_phase.marker(),
-                kind: ParsingErrorKind::Consuming { index },
+                kind: index.into(),
             }
         }
         NomErr::Incomplete(_) => kawa.parsing_phase,
@@ -45,7 +45,7 @@ fn handle_recovery_error<T: AsBuffer>(
             let index = kawa.storage.buffer().offset(primary_error.input) as u32;
             ParsingPhase::Error {
                 marker: kawa.parsing_phase.marker(),
-                kind: ParsingErrorKind::Consuming { index },
+                kind: index.into(),
             }
         }
         NomErr::Incomplete(_) => kawa.parsing_phase,

--- a/src/protocol/h1/parser/primitives.rs
+++ b/src/protocol/h1/parser/primitives.rs
@@ -85,7 +85,7 @@ impl std::ops::Deref for CharRanges {
     parsers are strict enough to ensure all slices are valid UTF-8, so from_utf8_uncheck can be
     used on them.
 */
-compile_lookup!(tchar => [0x00..0x20, '('..')', '['..']', '{', '}', ',', ':'..'@', 0x7F..0xFF]);
+compile_lookup!(pub tchar => [0x00..0x20, '('..')', '['..']', '{', '}', ',', ':'..'@', 0x7F..0xFF]);
 
 /*
     Creates a vchar module for preparsing URIs.
@@ -109,7 +109,7 @@ compile_lookup!(tchar => [0x00..0x20, '('..')', '['..']', '{', '}', ',', ':'..'@
     p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
 */
-compile_lookup!(vchar => [0x00..0x20, 0x7F..0xFF]);
+compile_lookup!(pub vchar => [0x00..0x20, 0x7F..0xFF]);
 
 /*
     Creates a ck_char and cv_char module for parsing cookie keys and values respectively.
@@ -135,8 +135,8 @@ compile_lookup!(vchar => [0x00..0x20, 0x7F..0xFF]);
 
     note: cookie values can contain equal signs and spaces, not keys.
 */
-compile_lookup!(ck_char => [0x00..0x20, ';', '=', 0x7F..0xFF]);
-compile_lookup!(cv_char => [0x00..0x1F, ';', 0x7F..0xFF]);
+compile_lookup!(pub ck_char => [0x00..0x20, ';', '=', 0x7F..0xFF]);
+compile_lookup!(pub cv_char => [0x00..0x1F, ';', 0x7F..0xFF]);
 
 /*
     Creates a achar module for parsing header values and http reasons.
@@ -160,7 +160,7 @@ compile_lookup!(cv_char => [0x00..0x1F, ';', 0x7F..0xFF]);
     p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
 */
-compile_lookup!(achar => [0x00..0x08, 0x0A..0x1F, 0x7F..0xFF]);
+compile_lookup!(pub achar => [0x00..0x08, 0x0A..0x1F, 0x7F..0xFF]);
 
 #[inline]
 fn space(i: &[u8]) -> IResult<&[u8], char> {

--- a/src/protocol/h1/parser/primitives.rs
+++ b/src/protocol/h1/parser/primitives.rs
@@ -57,6 +57,11 @@ impl std::ops::Deref for CharRanges {
 // STREAMING PARSERS
 //////////////////////////////////////////////////
 
+#[cfg(not(feature = "tolerant-parsing"))]
+const LAST_INVALID_CHAR: u8 = 0xFF;
+#[cfg(feature = "tolerant-parsing")]
+const LAST_INVALID_CHAR: u8 = 0x9F;
+
 /*
     Creates a tchar module for parsing header keys and http methods.
 
@@ -85,7 +90,7 @@ impl std::ops::Deref for CharRanges {
     parsers are strict enough to ensure all slices are valid UTF-8, so from_utf8_uncheck can be
     used on them.
 */
-compile_lookup!(pub tchar => [0x00..0x20, '('..')', '['..']', '{', '}', ',', ':'..'@', 0x7F..0xFF]);
+compile_lookup!(pub tchar => [0x00..0x20, '('..')', '['..']', '{', '}', ',', ':'..'@', 0x7F..LAST_INVALID_CHAR]);
 
 /*
     Creates a vchar module for preparsing URIs.
@@ -109,7 +114,7 @@ compile_lookup!(pub tchar => [0x00..0x20, '('..')', '['..']', '{', '}', ',', ':'
     p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
 */
-compile_lookup!(pub vchar => [0x00..0x20, 0x7F..0xFF]);
+compile_lookup!(pub vchar => [0x00..0x20, 0x7F..LAST_INVALID_CHAR]);
 
 /*
     Creates a ck_char and cv_char module for parsing cookie keys and values respectively.
@@ -135,8 +140,8 @@ compile_lookup!(pub vchar => [0x00..0x20, 0x7F..0xFF]);
 
     note: cookie values can contain equal signs and spaces, not keys.
 */
-compile_lookup!(pub ck_char => [0x00..0x20, ';', '=', 0x7F..0xFF]);
-compile_lookup!(pub cv_char => [0x00..0x1F, ';', 0x7F..0xFF]);
+compile_lookup!(pub ck_char => [0x00..0x20, ';', '=', 0x7F..LAST_INVALID_CHAR]);
+compile_lookup!(pub cv_char => [0x00..0x1F, ';', 0x7F..LAST_INVALID_CHAR]);
 
 /*
     Creates a achar module for parsing header values and http reasons.
@@ -160,7 +165,7 @@ compile_lookup!(pub cv_char => [0x00..0x1F, ';', 0x7F..0xFF]);
     p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
 */
-compile_lookup!(pub achar => [0x00..0x08, 0x0A..0x1F, 0x7F..0xFF]);
+compile_lookup!(pub achar => [0x00..0x08, 0x0A..0x1F, 0x7F..LAST_INVALID_CHAR]);
 
 #[inline]
 fn space(i: &[u8]) -> IResult<&[u8], char> {

--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -99,8 +99,8 @@ macro_rules! make_char_lookup {
 /// This macro an entire module which contains parsing utilities for a particular rule
 #[macro_export]
 macro_rules! compile_lookup {
-    ($name:ident => [$($t:tt)*]) => {
-        mod $name {
+    ($vis:vis $name:ident => [$($t:tt)*]) => {
+        $vis mod $name {
             use $crate::h1::parser::primitives::{CharLookup, CharRanges, CharTable};
             pub const LOOKUP: CharLookup = $crate::make_char_lookup!($($t)*);
             pub const TABLE: CharTable = LOOKUP.table;

--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -101,6 +101,8 @@ macro_rules! make_char_lookup {
 macro_rules! compile_lookup {
     ($vis:vis $name:ident => [$($t:tt)*]) => {
         $vis mod $name {
+            #[allow(unused_imports)]
+            use super::*;
             use $crate::h1::parser::primitives::{CharLookup, CharRanges, CharTable};
             pub const LOOKUP: CharLookup = $crate::make_char_lookup!($($t)*);
             pub const TABLE: CharTable = LOOKUP.table;

--- a/src/storage/buffer.rs
+++ b/src/storage/buffer.rs
@@ -146,7 +146,7 @@ impl<T: AsBuffer> Buffer<T> {
         &mut self.mut_buffer()[range]
     }
 
-    pub fn used(&mut self) -> &[u8] {
+    pub fn used(&self) -> &[u8] {
         let range = ..self.end;
         &self.buffer()[range]
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,8 +6,8 @@ pub mod vecdeque;
 pub use buffer::{AsBuffer, Buffer};
 pub use debug::debug_kawa;
 pub use repr::{
-    Block, BodySize, Chunk, ChunkHeader, Flags, Kawa, Kind, OutBlock, Pair, ParsingPhase,
-    StatusLine, Store, Version,
+    Block, BodySize, Chunk, ChunkHeader, Flags, Kawa, Kind, OutBlock, Pair, ParsingErrorKind,
+    ParsingPhase, ParsingPhaseMarker, StatusLine, Store, Version,
 };
 pub use vecdeque::VecDeque;
 

--- a/src/storage/repr.rs
+++ b/src/storage/repr.rs
@@ -240,6 +240,11 @@ impl From<&'static str> for ParsingErrorKind {
         Self::Processing { message }
     }
 }
+impl From<u32> for ParsingErrorKind {
+    fn from(index: u32) -> Self {
+        ParsingErrorKind::Consuming { index }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParsingPhase {


### PR DESCRIPTION
H1 parsing enhancements:
- fix head not updating correctly: necessary for successful requests pipelining
- better error handling: enables clear error messages
- add support for ISO-8859-1: this enables most Western European characters in HTTP headers