### PR TITLE
fix: Do not try to build sse3 code if the target feature is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Agnostic representation of HTTP/1.1 and HTTP/2.0 for parsing, generating and translating HTTP
 messages, with zero-copy, made for Sōzu.
 
+## SIMD support
+
+The default `simd` feature uses the optimized parser on `x86_64` targets compiled with SSE4.2.
+Other architectures and x86_64 targets without SSE4.2 automatically use the scalar parser.
+
 # Principles
 
 Consider the following HTTP/1.1 response stored in a `Buffer`:

--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -119,7 +119,7 @@ macro_rules! compile_lookup {
             }
 
             #[inline]
-            #[cfg(feature="simd")]
+            #[cfg(all(feature="simd", target_feature="sse3"))]
             /// Returns the longest string that fits the rule (simd optimized)
             ///
             /// *Streaming version* will return a Err::Incomplete(Needed::Unknown) if the pattern reaches the end of the input.
@@ -177,7 +177,7 @@ macro_rules! compile_lookup {
             }
 
             #[inline]
-            #[cfg(feature="simd")]
+            #[cfg(all(feature="simd", target_feature="sse3"))]
             /// Returns the longest string that fits the rule (simd optimized)
             fn take_while_complete_simd(input: &[u8]) -> nom::IResult<&[u8], &[u8]> {
                 use std::arch::x86_64::{
@@ -278,9 +278,9 @@ macro_rules! compile_lookup {
             ///
             /// *Streaming version* will return a Err::Incomplete(Needed::Unknown) if the pattern reaches the end of the input.
             pub fn take_while_fast(input: &[u8]) -> nom::IResult<&[u8], &[u8]> {
-                #[cfg(feature="simd")]
+                #[cfg(all(feature="simd", target_feature="sse3"))]
                 let result = take_while_simd(input);
-                #[cfg(not(feature="simd"))]
+                #[cfg(any(not(feature="simd"), not(target_feature="sse3")))]
                 let result = take_while(input);
                 result
             }
@@ -289,9 +289,9 @@ macro_rules! compile_lookup {
             #[allow(dead_code)]
             /// Returns the longest string that fits the rule (using simd if enabled)
             pub fn take_while_complete_fast(input: &[u8]) -> nom::IResult<&[u8], &[u8]> {
-                #[cfg(feature="simd")]
+                #[cfg(all(feature="simd", target_feature="sse3"))]
                 let result = take_while_complete_simd(input);
-                #[cfg(not(feature="simd"))]
+                #[cfg(any(not(feature="simd"), not(target_feature="sse3")))]
                 let result = take_while_complete(input);
                 result
             }

--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -119,7 +119,11 @@ macro_rules! compile_lookup {
             }
 
             #[inline]
-            #[cfg(all(feature="simd", target_feature="sse3"))]
+            #[cfg(all(
+                feature = "simd",
+                target_arch = "x86_64",
+                target_feature = "sse4.2"
+            ))]
             /// Returns the longest string that fits the rule (simd optimized)
             ///
             /// *Streaming version* will return a Err::Incomplete(Needed::Unknown) if the pattern reaches the end of the input.
@@ -177,7 +181,11 @@ macro_rules! compile_lookup {
             }
 
             #[inline]
-            #[cfg(all(feature="simd", target_feature="sse3"))]
+            #[cfg(all(
+                feature = "simd",
+                target_arch = "x86_64",
+                target_feature = "sse4.2"
+            ))]
             /// Returns the longest string that fits the rule (simd optimized)
             fn take_while_complete_simd(input: &[u8]) -> nom::IResult<&[u8], &[u8]> {
                 use std::arch::x86_64::{
@@ -278,9 +286,17 @@ macro_rules! compile_lookup {
             ///
             /// *Streaming version* will return a Err::Incomplete(Needed::Unknown) if the pattern reaches the end of the input.
             pub fn take_while_fast(input: &[u8]) -> nom::IResult<&[u8], &[u8]> {
-                #[cfg(all(feature="simd", target_feature="sse3"))]
+                #[cfg(all(
+                    feature = "simd",
+                    target_arch = "x86_64",
+                    target_feature = "sse4.2"
+                ))]
                 let result = take_while_simd(input);
-                #[cfg(any(not(feature="simd"), not(target_feature="sse3")))]
+                #[cfg(not(all(
+                    feature = "simd",
+                    target_arch = "x86_64",
+                    target_feature = "sse4.2"
+                )))]
                 let result = take_while(input);
                 result
             }
@@ -289,9 +305,17 @@ macro_rules! compile_lookup {
             #[allow(dead_code)]
             /// Returns the longest string that fits the rule (using simd if enabled)
             pub fn take_while_complete_fast(input: &[u8]) -> nom::IResult<&[u8], &[u8]> {
-                #[cfg(all(feature="simd", target_feature="sse3"))]
+                #[cfg(all(
+                    feature = "simd",
+                    target_arch = "x86_64",
+                    target_feature = "sse4.2"
+                ))]
                 let result = take_while_complete_simd(input);
-                #[cfg(any(not(feature="simd"), not(target_feature="sse3")))]
+                #[cfg(not(all(
+                    feature = "simd",
+                    target_arch = "x86_64",
+                    target_feature = "sse4.2"
+                )))]
                 let result = take_while_complete(input);
                 result
             }

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -4,7 +4,7 @@ use kawa::{h1, Buffer, Kawa, Kind, SliceBuffer};
 
 #[test]
 fn bench_long() {
-    const REQ_LONG: &'static [u8] = b"\
+    const REQ_LONG: &[u8] = b"\
 GET /wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg HTTP/1.1\r\n\
 Host: www.kittyhell.com\r\n\
 User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9\r\n\
@@ -18,17 +18,17 @@ Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; foo; ==bar=; 
 
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQ_LONG).expect("write");
+    req.storage.write_all(REQ_LONG).expect("write");
     req.blocks.reserve(16);
     req.detached.jar.reserve(16);
     for _ in 0..10_000_000 {
         req.clear();
         req.storage.clear();
         req.storage.fill(REQ_LONG.len());
-        black_box(h1::parse(&mut req, &mut h1::NoCallbacks));
+        h1::parse(black_box(&mut req), &mut h1::NoCallbacks);
         if !req.is_main_phase() {
             kawa::debug_kawa(&req);
-            assert!(false);
+            panic!("parser did not reach the main phase");
         }
     }
     kawa::debug_kawa(&req);
@@ -36,23 +36,23 @@ Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; foo; ==bar=; 
 
 #[test]
 fn bench_short() {
-    const REQ_SHORT: &'static [u8] = b"\
+    const REQ_SHORT: &[u8] = b"\
 GET / HTTP/1.0\r\n\
 Host: example.com\r\n\
 Connection: close\r\n\r\n";
 
     let mut buffer = vec![0; 512];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQ_SHORT).expect("write");
+    req.storage.write_all(REQ_SHORT).expect("write");
     req.blocks.reserve(16);
     for _ in 0..10_000_000 {
         req.clear();
         req.storage.clear();
         req.storage.fill(REQ_SHORT.len());
-        black_box(h1::parse(&mut req, &mut h1::NoCallbacks));
+        h1::parse(black_box(&mut req), &mut h1::NoCallbacks);
         if !req.is_main_phase() {
             kawa::debug_kawa(&req);
-            assert!(false);
+            panic!("parser did not reach the main phase");
         }
     }
     kawa::debug_kawa(&req);

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -4,14 +4,14 @@ use kawa::{h1, Block, BodySize, Buffer, Kawa, Kind, SliceBuffer};
 
 #[test]
 fn compressed_chunked() {
-    const REQUEST: &'static [u8] = b"\
+    const REQUEST: &[u8] = b"\
 GET /image.jpg HTTP/1.1\r\n\
 Host: www.compressed.com\r\n\
 Transfer-Encoding: gzip,chunked\r\n\r\n0\r\n\r\n";
 
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQUEST).expect("write");
+    req.storage.write_all(REQUEST).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     kawa::debug_kawa(&req);
     assert!(req.is_streaming());
@@ -21,12 +21,12 @@ Transfer-Encoding: gzip,chunked\r\n\r\n0\r\n\r\n";
 
 #[test]
 fn multiple_content_length() {
-    const REQUEST_VALID: &'static [u8] = b"\
+    const REQUEST_VALID: &[u8] = b"\
 GET /image.jpg HTTP/1.1\r\n\
 Host: www.compressed.com\r\n\
 Content-Length: 3\r\n\
 Content-Length: 3\r\n\r\nABC";
-    const REQUEST_INVALID: &'static [u8] = b"\
+    const REQUEST_INVALID: &[u8] = b"\
 GET /image.jpg HTTP/1.1\r\n\
 Host: www.compressed.com\r\n\
 Content-Length: 3\r\n\
@@ -34,7 +34,7 @@ Content-Length: 4\r\n\r\nABCD";
 
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQUEST_VALID).expect("write");
+    req.storage.write_all(REQUEST_VALID).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     kawa::debug_kawa(&req);
     assert!(req.body_size == BodySize::Length(3));
@@ -42,7 +42,7 @@ Content-Length: 4\r\n\r\nABCD";
     assert!(req.storage.unparsed_data().is_empty());
 
     req.clear();
-    req.storage.write(REQUEST_INVALID).expect("write");
+    req.storage.write_all(REQUEST_INVALID).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     kawa::debug_kawa(&req);
     assert!(req.is_error());
@@ -50,7 +50,7 @@ Content-Length: 4\r\n\r\nABCD";
 
 #[test]
 fn multiple_length_information() {
-    const REQUEST: &'static [u8] = b"\
+    const REQUEST: &[u8] = b"\
 GET /image.jpg HTTP/1.1\r\n\
 Host: www.compressed.com\r\n\
 Content-Length: 3\r\n\
@@ -61,13 +61,13 @@ Content-Length: 4\r\n\r\n0\r\n\r\n";
 
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQUEST).expect("write");
+    req.storage.write_all(REQUEST).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     kawa::debug_kawa(&req);
     assert!(req.is_terminated());
     assert!(req.is_streaming());
     assert!(req.storage.unparsed_data().is_empty());
-    for block in req.blocks {
+    for block in &req.blocks {
         if let Block::Header(header) = block {
             if let Some(key) = header.key.data_opt(&buffer) {
                 assert_ne!(key, b"Content-Length");
@@ -96,7 +96,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert_eq!(req.body_size, BodySize::Chunked);
         assert!(!req.is_error());
@@ -109,7 +109,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding: chunked\t\r\n\r\n0\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert_eq!(req.body_size, BodySize::Chunked);
         assert!(!req.is_error());
@@ -122,7 +122,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding:  chunked \r\n\r\n0\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert_eq!(req.body_size, BodySize::Chunked);
         assert!(!req.is_error());
@@ -135,7 +135,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert_eq!(req.body_size, BodySize::Chunked);
         assert!(!req.is_error());
@@ -148,7 +148,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding: chunked, gzip\r\n\r\nabc";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert!(req.is_error());
     }
@@ -160,7 +160,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding: identity\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert!(req.is_error());
     }
@@ -172,7 +172,7 @@ GET / HTTP/1.1\r\n\
 Host: example.com\r\n\
 Transfer-Encoding: xchunked\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert!(req.is_error());
     }
@@ -190,7 +190,7 @@ Content-Length: 3\r\n\
 Transfer-Encoding: chunked\t\r\n\r\n0\r\n\r\n";
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQUEST).expect("write");
+    req.storage.write_all(REQUEST).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     assert_eq!(req.body_size, BodySize::Chunked);
     assert!(!req.is_error());
@@ -223,7 +223,7 @@ Host: example.com\r\n\
 Transfer-Encoding: gzip\r\n\
 Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert_eq!(req.body_size, BodySize::Chunked);
         assert!(!req.is_error());
@@ -240,7 +240,7 @@ Host: example.com\r\n\
 Transfer-Encoding: chunked\r\n\
 Transfer-Encoding: identity\r\n\r\n";
         let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-        req.storage.write(REQUEST).expect("write");
+        req.storage.write_all(REQUEST).expect("write");
         h1::parse(&mut req, &mut h1::NoCallbacks);
         assert!(req.is_error());
     }
@@ -262,7 +262,7 @@ fn transfer_encoding_response_non_chunked_final_is_not_an_error() {
 HTTP/1.1 200 OK\r\n\
 Transfer-Encoding: gzip\r\n\r\n";
         let mut resp = Kawa::new(Kind::Response, Buffer::new(SliceBuffer(&mut buffer[..])));
-        resp.storage.write(RESPONSE).expect("write");
+        resp.storage.write_all(RESPONSE).expect("write");
         h1::parse(&mut resp, &mut h1::NoCallbacks);
         assert!(!resp.is_error());
         // No Content-Length was present, so the pre-fix reference value
@@ -279,7 +279,7 @@ Transfer-Encoding: gzip\r\n\r\n";
 HTTP/1.1 200 OK\r\n\
 Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
         let mut resp = Kawa::new(Kind::Response, Buffer::new(SliceBuffer(&mut buffer[..])));
-        resp.storage.write(RESPONSE).expect("write");
+        resp.storage.write_all(RESPONSE).expect("write");
         h1::parse(&mut resp, &mut h1::NoCallbacks);
         assert_eq!(resp.body_size, BodySize::Chunked);
         assert!(!resp.is_error());
@@ -297,7 +297,7 @@ HTTP/1.1 200 OK\r\n\
 Transfer-Encoding: chunked\r\n\
 Transfer-Encoding: identity\r\n\r\n";
         let mut resp = Kawa::new(Kind::Response, Buffer::new(SliceBuffer(&mut buffer[..])));
-        resp.storage.write(RESPONSE).expect("write");
+        resp.storage.write_all(RESPONSE).expect("write");
         h1::parse(&mut resp, &mut h1::NoCallbacks);
         assert!(!resp.is_error());
         assert_eq!(resp.body_size, BodySize::Empty);
@@ -306,14 +306,14 @@ Transfer-Encoding: identity\r\n\r\n";
 
 #[test]
 fn malformed_cookies_separator() {
-    const REQUEST: &'static [u8] = b"\
+    const REQUEST: &[u8] = b"\
 GET /cookies HTTP/1.1\r\n\
 Host: www.bad.com\r\n\
 Cookie: a=1; b=2;c=3; foo; ==bar=\r\n\r\n0\r\n\r\n";
 
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQUEST).expect("write");
+    req.storage.write_all(REQUEST).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     kawa::debug_kawa(&req);
     assert!(req.storage.unparsed_data().is_empty());
@@ -337,14 +337,14 @@ Cookie: a=1; b=2;c=3; foo; ==bar=\r\n\r\n0\r\n\r\n";
 
 #[test]
 fn spaces_in_cookie() {
-    const REQUEST: &'static [u8] = b"\
+    const REQUEST: &[u8] = b"\
 GET /cookies HTTP/1.1\r\n\
 Host: www.bad.com\r\n\
 Cookie: a=b;  c d e  = fg h ;i=j;  k   l=  mn  \r\n\r\n0\r\n\r\n";
 
     let mut buffer = vec![0; 4096];
     let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
-    req.storage.write(REQUEST).expect("write");
+    req.storage.write_all(REQUEST).expect("write");
     h1::parse(&mut req, &mut h1::NoCallbacks);
     kawa::debug_kawa(&req);
     assert!(req.storage.unparsed_data().is_empty());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,7 @@ fn test_with_converter<T: AsBuffer, C: BlockConverter<T>>(
 ) -> T {
     println!("////////////////////////////////////////");
     let mut kawa = Kawa::new(kind, storage);
-    let _ = kawa.storage.write(fragment).expect("WRITE");
+    kawa.storage.write_all(fragment).expect("WRITE");
     debug_kawa(&kawa);
 
     h1::parse(&mut kawa, &mut h1::NoCallbacks);
@@ -38,8 +38,7 @@ fn test<T: AsBuffer>(kind: Kind, storage: T, fragment: &[u8]) -> T {
     let buffer = Buffer::new(storage);
     let storage = test_with_converter(kind, buffer, fragment, &mut h1::BlockConverter);
     let buffer = Buffer::new(storage);
-    let storage = test_with_converter(kind, buffer, fragment, &mut h2::BlockConverter);
-    storage
+    test_with_converter(kind, buffer, fragment, &mut h2::BlockConverter)
 }
 
 fn test_partial_with_converter<T: AsBuffer, C: BlockConverter<T>>(
@@ -53,7 +52,7 @@ fn test_partial_with_converter<T: AsBuffer, C: BlockConverter<T>>(
 
     while !fragments.is_empty() {
         let fragment = fragments.remove(0);
-        let _ = kawa.storage.write(fragment).expect("WRITE");
+        kawa.storage.write_all(fragment).expect("WRITE");
 
         let buffer = unsafe { std::str::from_utf8_unchecked(kawa.storage.used()) };
         println!("===============================\n{buffer}\n===============================");
@@ -84,13 +83,12 @@ fn test_partial<T: AsBuffer>(kind: Kind, storage: T, fragments: Vec<&[u8]>) -> T
         fragments.clone(),
         &mut h1::BlockConverter,
     );
-    let storage = test_partial_with_converter(
+    test_partial_with_converter(
         kind,
         Buffer::new(storage),
         fragments,
         &mut h2::BlockConverter,
-    );
-    storage
+    )
 }
 
 #[test]

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -4,7 +4,7 @@ use kawa::{h1, Buffer, Kawa, Kind, SliceBuffer};
 
 #[test]
 fn bench_long() {
-    const REQ_LONG: &'static [u8] = b"\
+    const REQ_LONG: &[u8] = b"\
 GET /wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg HTTP/1.1\r\n\
 Host: www.kittyhell.com\r\n\
 User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9\r\n\
@@ -25,19 +25,19 @@ Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; foo; ==bar=; 
         req.clear();
         req.storage.clear();
         for char in REQ_LONG {
-            req.storage.write(&[*char]).expect("write");
-            black_box(h1::parse(&mut req, &mut h1::NoCallbacks));
+            req.storage.write_all(&[*char]).expect("write");
+            h1::parse(black_box(&mut req), &mut h1::NoCallbacks);
         }
         if !req.is_main_phase() {
             kawa::debug_kawa(&req);
-            assert!(false);
+            panic!("parser did not reach the main phase");
         }
     }
 }
 
 #[test]
 fn bench_short() {
-    const REQ_SHORT: &'static [u8] = b"\
+    const REQ_SHORT: &[u8] = b"\
 GET / HTTP/1.0\r\n\
 Host: example.com\r\n\
 Connection: close\r\n\r\n";
@@ -50,12 +50,12 @@ Connection: close\r\n\r\n";
         req.clear();
         req.storage.clear();
         for char in REQ_SHORT {
-            req.storage.write(&[*char]).expect("write");
-            black_box(h1::parse(&mut req, &mut h1::NoCallbacks));
+            req.storage.write_all(&[*char]).expect("write");
+            h1::parse(black_box(&mut req), &mut h1::NoCallbacks);
         }
         if !req.is_main_phase() {
             kawa::debug_kawa(&req);
-            assert!(false);
+            panic!("parser did not reach the main phase");
         }
     }
 }


### PR DESCRIPTION
It should tackle the main annoyance of #4 and also prevent sigills if for whichever reason sse3 disabled on x86_64.

It will require to build passing an appropriate `-Ctarget-cpu`.