### PR TITLE
Elide Content-Length if streaming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub use storage::*;
 
 pub struct SliceBuffer<'a>(pub &'a mut [u8]);
 
-impl<'a> crate::AsBuffer for SliceBuffer<'a> {
+impl crate::AsBuffer for SliceBuffer<'_> {
     fn as_buffer(&self) -> &[u8] {
         self.0
     }

--- a/src/storage/vecdeque.rs
+++ b/src/storage/vecdeque.rs
@@ -271,7 +271,7 @@ impl<'a, T: Sized> Iterator for IterMut<'a, T> {
         Some(unsafe { &mut *self.ring.add(self.index) })
     }
 }
-impl<'a, T: Sized> Iterator for Drain<'a, T> {
+impl<T: Sized> Iterator for Drain<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
`Content-Length` was already elided when it appeared after `Transfer-Encoding: chunked`, but not before. This is fixed to comply with the RFC and avoid potential request smuggling.