### PR TITLE
fix(h1): require chunked as the final transfer-coding, trim OWS

### DIFF
--- a/src/protocol/h1/parser/mod.rs
+++ b/src/protocol/h1/parser/mod.rs
@@ -98,6 +98,17 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
     };
 
     let mut content_length = None;
+    // Tracks whether the MOST RECENTLY seen Transfer-Encoding field line, on
+    // its own, does NOT end in the chunked coding. RFC 9110 §5.3 makes
+    // repeated Transfer-Encoding field lines equivalent to a single
+    // comma-joined value in order, so the combined final transfer-coding is
+    // the final coding of the LAST such line -- a split "gzip" then
+    // "chunked" is the same wire semantics as one "gzip, chunked" line and
+    // must not be rejected on the first line. The reject decision below is
+    // therefore deferred until every header block has been walked, using
+    // only the last-seen line's outcome; a later chunked-final line clears
+    // this flag and applies chunked framing immediately (see the loop body).
+    let mut transfer_encoding_pending_reject = false;
     for block in &mut kawa.blocks {
         if let Block::Header(header) = block {
             let Store::Slice(key) = &header.key else {
@@ -142,43 +153,55 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
             } else if compare_no_case(key, b"transfer-encoding") {
                 let val = header.val.data(buf);
                 // RFC 9112 §6.1: "the chunked transfer coding MUST be
-                // applied last" -- an intermediary can only trust
-                // Transfer-Encoding for message framing when "chunked" is
-                // the FINAL transfer-coding in the (possibly
+                // applied last" -- chunked framing is only selected when
+                // "chunked" is the FINAL transfer-coding in the (possibly
                 // comma-separated) value, once OWS (space/HTAB, RFC 9110
                 // §5.6.3) around the value and each token is trimmed.
-                // RFC 9112 §6.3 mandates rejecting a request whose
-                // Transfer-Encoding is present but does not end in
-                // chunked, because the message body length can then not
-                // be determined reliably. Closes sozu-proxy/sozu#726: the
-                // previous suffix-only, untrimmed check let a value like
-                // "chunked\t" (trailing tab) neither match nor error,
-                // leaving Content-Length framing active while the
-                // malformed Transfer-Encoding header stayed un-elided --
-                // i.e. both framing headers were forwarded to the
-                // backend. It also let "xchunked" false-positive as
-                // chunked.
-                if !ends_with_chunked_coding(val) {
-                    kawa.parsing_phase.error(
-                        "Transfer-Encoding present without chunked as the final coding".into(),
-                    );
-                    return;
-                }
-                match kawa.body_size {
-                    BodySize::Empty => {}
-                    BodySize::Chunked => {
-                        warn!("Found multiple Transfer-Encoding");
-                    }
-                    BodySize::Length(_) => {
-                        warn!("Found both a Content-Length and a Transfer-Encoding, ignoring the former");
-                        if let Some(content_length) = content_length.take() {
-                            content_length.elide();
+                // Closes sozu-proxy/sozu#726: the previous suffix-only,
+                // untrimmed check let a value like "chunked\t" (trailing
+                // tab) neither match nor error, leaving Content-Length
+                // framing active while the malformed Transfer-Encoding
+                // header stayed un-elided -- i.e. both framing headers
+                // were forwarded to the backend. It also let "xchunked"
+                // false-positive as chunked.
+                if ends_with_chunked_coding(val) {
+                    transfer_encoding_pending_reject = false;
+                    match kawa.body_size {
+                        BodySize::Empty => {}
+                        BodySize::Chunked => {
+                            warn!("Found multiple Transfer-Encoding");
+                        }
+                        BodySize::Length(_) => {
+                            warn!("Found both a Content-Length and a Transfer-Encoding, ignoring the former");
+                            if let Some(content_length) = content_length.take() {
+                                content_length.elide();
+                            }
                         }
                     }
+                    kawa.body_size = BodySize::Chunked;
+                } else {
+                    // This line's own final coding is not chunked. It may
+                    // still be superseded by a later Transfer-Encoding
+                    // field line (the split-header case above), so defer
+                    // the reject decision instead of erroring here.
+                    transfer_encoding_pending_reject = true;
                 }
-                kawa.body_size = BodySize::Chunked;
             }
         }
+    }
+    if transfer_encoding_pending_reject && kawa.kind == Kind::Request {
+        // RFC 9112 §6.3 mandates rejecting a REQUEST whose
+        // Transfer-Encoding is present but does not end in chunked,
+        // because the message body length can then not be determined
+        // reliably. This rule does not apply to responses: a response
+        // with a non-chunked-final Transfer-Encoding (e.g. "gzip" alone)
+        // is spec-valid and its body is close-delimited (read until
+        // connection close) instead of an error, so body_size is left
+        // exactly as Content-Length processing above produced it
+        // (Length(n) or Empty).
+        kawa.parsing_phase
+            .error("Transfer-Encoding present without chunked as the final coding".into());
+        return;
     }
     match &mut kawa.detached.status_line {
         StatusLine::Request {

--- a/src/protocol/h1/parser/mod.rs
+++ b/src/protocol/h1/parser/mod.rs
@@ -97,18 +97,29 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
         _ => (Store::Empty, Store::Empty),
     };
 
-    let mut content_length = None;
-    // Tracks whether the MOST RECENTLY seen Transfer-Encoding field line, on
-    // its own, does NOT end in the chunked coding. RFC 9110 §5.3 makes
-    // repeated Transfer-Encoding field lines equivalent to a single
-    // comma-joined value in order, so the combined final transfer-coding is
-    // the final coding of the LAST such line -- a split "gzip" then
-    // "chunked" is the same wire semantics as one "gzip, chunked" line and
-    // must not be rejected on the first line. The reject decision below is
-    // therefore deferred until every header block has been walked, using
-    // only the last-seen line's outcome; a later chunked-final line clears
-    // this flag and applies chunked framing immediately (see the loop body).
-    let mut transfer_encoding_pending_reject = false;
+    // Transfer-Encoding is resolved up front, before Content-Length, because
+    // repeated Transfer-Encoding field lines combine (RFC 9110 §5.3) and the
+    // combined final transfer-coding is the final coding of the LAST line: a
+    // split "gzip" then "chunked" frames as chunked, while "chunked" then a
+    // later non-chunked line (e.g. "identity") does NOT -- the combined final
+    // coding wins, so an earlier "chunked" line must never latch chunked
+    // framing on its own. Knowing Transfer-Encoding presence up front also lets
+    // Content-Length processing honor RFC 9110 §6.3 (a present Transfer-Encoding
+    // overrides Content-Length) regardless of header order.
+    let mut transfer_encoding_present = false;
+    let mut transfer_encoding_final_chunked = false;
+    for block in &kawa.blocks {
+        if let Block::Header(header) = block {
+            if let Store::Slice(key) = &header.key {
+                if compare_no_case(key.data(buf), b"transfer-encoding") {
+                    transfer_encoding_present = true;
+                    transfer_encoding_final_chunked =
+                        ends_with_chunked_coding(header.val.data(buf));
+                }
+            }
+        }
+    }
+
     for block in &mut kawa.blocks {
         if let Block::Header(header) = block {
             let Store::Slice(key) = &header.key else {
@@ -122,6 +133,19 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
                 }
                 header.elide(); // Host header is elided
             } else if compare_no_case(key, b"content-length") {
+                if transfer_encoding_present {
+                    // RFC 9110 §6.3: when both Transfer-Encoding and
+                    // Content-Length are present, the Transfer-Encoding
+                    // overrides the Content-Length. Drop every Content-Length
+                    // so a single, unambiguous framing reaches downstream
+                    // (anti-smuggling), and do not length-reconcile a value
+                    // that no longer frames the body.
+                    warn!(
+                        "Found both a Transfer-Encoding and a Content-Length, ignoring the latter"
+                    );
+                    header.elide();
+                    continue;
+                }
                 let length = match header.val.data(buf).parse_to() {
                     Some(length) => length,
                     None => {
@@ -132,13 +156,7 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
                 };
                 match kawa.body_size {
                     BodySize::Empty => {
-                        content_length = Some(header);
                         kawa.body_size = BodySize::Length(length);
-                    }
-                    BodySize::Chunked => {
-                        warn!("Found both a Transfer-Encoding and a Content-Length, ignoring the latter");
-                        header.elide();
-                        continue;
                     }
                     BodySize::Length(previous_length) => {
                         if previous_length != length {
@@ -149,59 +167,35 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
                             header.elide();
                         }
                     }
-                }
-            } else if compare_no_case(key, b"transfer-encoding") {
-                let val = header.val.data(buf);
-                // RFC 9112 §6.1: "the chunked transfer coding MUST be
-                // applied last" -- chunked framing is only selected when
-                // "chunked" is the FINAL transfer-coding in the (possibly
-                // comma-separated) value, once OWS (space/HTAB, RFC 9110
-                // §5.6.3) around the value and each token is trimmed.
-                // Closes sozu-proxy/sozu#726: the previous suffix-only,
-                // untrimmed check let a value like "chunked\t" (trailing
-                // tab) neither match nor error, leaving Content-Length
-                // framing active while the malformed Transfer-Encoding
-                // header stayed un-elided -- i.e. both framing headers
-                // were forwarded to the backend. It also let "xchunked"
-                // false-positive as chunked.
-                if ends_with_chunked_coding(val) {
-                    transfer_encoding_pending_reject = false;
-                    match kawa.body_size {
-                        BodySize::Empty => {}
-                        BodySize::Chunked => {
-                            warn!("Found multiple Transfer-Encoding");
-                        }
-                        BodySize::Length(_) => {
-                            warn!("Found both a Content-Length and a Transfer-Encoding, ignoring the former");
-                            if let Some(content_length) = content_length.take() {
-                                content_length.elide();
-                            }
-                        }
-                    }
-                    kawa.body_size = BodySize::Chunked;
-                } else {
-                    // This line's own final coding is not chunked. It may
-                    // still be superseded by a later Transfer-Encoding
-                    // field line (the split-header case above), so defer
-                    // the reject decision instead of erroring here.
-                    transfer_encoding_pending_reject = true;
+                    // Unreachable while `transfer_encoding_present` is false
+                    // (chunked framing is only selected after this loop); elide
+                    // defensively rather than panic on network-controlled input.
+                    BodySize::Chunked => header.elide(),
                 }
             }
+            // Transfer-Encoding header lines are intentionally left in place
+            // (forwarded as received); their combined framing was resolved by
+            // the pre-scan above.
         }
     }
-    if transfer_encoding_pending_reject && kawa.kind == Kind::Request {
-        // RFC 9112 §6.3 mandates rejecting a REQUEST whose
-        // Transfer-Encoding is present but does not end in chunked,
-        // because the message body length can then not be determined
-        // reliably. This rule does not apply to responses: a response
-        // with a non-chunked-final Transfer-Encoding (e.g. "gzip" alone)
-        // is spec-valid and its body is close-delimited (read until
-        // connection close) instead of an error, so body_size is left
-        // exactly as Content-Length processing above produced it
-        // (Length(n) or Empty).
-        kawa.parsing_phase
-            .error("Transfer-Encoding present without chunked as the final coding".into());
-        return;
+    if transfer_encoding_present {
+        if transfer_encoding_final_chunked {
+            // The combined Transfer-Encoding ends in chunked -> chunked
+            // framing. Any Content-Length was already elided above.
+            kawa.body_size = BodySize::Chunked;
+        } else if kawa.kind == Kind::Request {
+            // RFC 9112 §6.3: a REQUEST whose combined Transfer-Encoding does
+            // not end in chunked has no reliably determinable body length, so
+            // reject rather than forward ambiguous framing.
+            kawa.parsing_phase
+                .error("Transfer-Encoding present without chunked as the final coding".into());
+            return;
+        }
+        // else: a RESPONSE with a non-chunked-final Transfer-Encoding is
+        // spec-valid and close-delimited (read until connection close). The
+        // Content-Length was removed above, so body_size stays Empty; a leading
+        // `chunked` line does NOT force chunked framing here, because the
+        // combined final coding is what determines message framing.
     }
     match &mut kawa.detached.status_line {
         StatusLine::Request {

--- a/src/protocol/h1/parser/mod.rs
+++ b/src/protocol/h1/parser/mod.rs
@@ -52,6 +52,29 @@ fn handle_recovery_error<T: AsBuffer>(
     }
 }
 
+/// Trims leading and trailing optional whitespace (OWS) as defined by
+/// RFC 9110 §5.6.3: space (0x20) and horizontal tab (0x09).
+#[inline]
+fn trim_ows(mut data: &[u8]) -> &[u8] {
+    while let [b' ' | b'\t', rest @ ..] = data {
+        data = rest;
+    }
+    while let [rest @ .., b' ' | b'\t'] = data {
+        data = rest;
+    }
+    data
+}
+
+/// Returns true if the FINAL comma-separated transfer-coding token of a
+/// Transfer-Encoding header value is `chunked`, case-insensitively, once
+/// OWS has been trimmed from around the token (RFC 9112 §6.1).
+#[inline]
+fn ends_with_chunked_coding(val: &[u8]) -> bool {
+    const CHUNKED: &[u8] = b"chunked";
+    let last_token = val.rsplit(|&b| b == b',').next().unwrap_or(val);
+    compare_no_case(trim_ows(last_token), CHUNKED)
+}
+
 fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
     let buf = kawa.storage.buffer();
 
@@ -118,24 +141,42 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
                 }
             } else if compare_no_case(key, b"transfer-encoding") {
                 let val = header.val.data(buf);
-                const CHUNKED: &[u8] = b"chunked";
-                if val.len() >= CHUNKED.len()
-                    && compare_no_case(&val[val.len() - CHUNKED.len()..], CHUNKED)
-                {
-                    match kawa.body_size {
-                        BodySize::Empty => {}
-                        BodySize::Chunked => {
-                            warn!("Found multiple Transfer-Encoding");
-                        }
-                        BodySize::Length(_) => {
-                            warn!("Found both a Content-Length and a Transfer-Encoding, ignoring the former");
-                            if let Some(content_length) = content_length.take() {
-                                content_length.elide();
-                            }
+                // RFC 9112 §6.1: "the chunked transfer coding MUST be
+                // applied last" -- an intermediary can only trust
+                // Transfer-Encoding for message framing when "chunked" is
+                // the FINAL transfer-coding in the (possibly
+                // comma-separated) value, once OWS (space/HTAB, RFC 9110
+                // §5.6.3) around the value and each token is trimmed.
+                // RFC 9112 §6.3 mandates rejecting a request whose
+                // Transfer-Encoding is present but does not end in
+                // chunked, because the message body length can then not
+                // be determined reliably. Closes sozu-proxy/sozu#726: the
+                // previous suffix-only, untrimmed check let a value like
+                // "chunked\t" (trailing tab) neither match nor error,
+                // leaving Content-Length framing active while the
+                // malformed Transfer-Encoding header stayed un-elided --
+                // i.e. both framing headers were forwarded to the
+                // backend. It also let "xchunked" false-positive as
+                // chunked.
+                if !ends_with_chunked_coding(val) {
+                    kawa.parsing_phase.error(
+                        "Transfer-Encoding present without chunked as the final coding".into(),
+                    );
+                    return;
+                }
+                match kawa.body_size {
+                    BodySize::Empty => {}
+                    BodySize::Chunked => {
+                        warn!("Found multiple Transfer-Encoding");
+                    }
+                    BodySize::Length(_) => {
+                        warn!("Found both a Content-Length and a Transfer-Encoding, ignoring the former");
+                        if let Some(content_length) = content_length.take() {
+                            content_length.elide();
                         }
                     }
-                    kawa.body_size = BodySize::Chunked;
                 }
+                kawa.body_size = BodySize::Chunked;
             }
         }
     }

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -77,6 +77,133 @@ Content-Length: 4\r\n\r\n0\r\n\r\n";
 }
 
 #[test]
+fn transfer_encoding_ows_and_final_coding() {
+    // RFC 9112 §6.1 / RFC 9110 §5.6.3: chunked framing is selected only
+    // when "chunked" is the FINAL transfer-coding, after trimming OWS
+    // (SP/HTAB) from the header value and from each comma-separated
+    // token. This is a regression test for sozu-proxy/sozu#726: the
+    // pre-fix code did a suffix-only, untrimmed compare, so a value like
+    // "chunked\t" (trailing tab) neither matched nor was rejected, and
+    // Content-Length framing silently stayed active while the malformed
+    // Transfer-Encoding header was left un-elided -- both framing headers
+    // reached the backend.
+    let mut buffer = vec![0; 4096];
+
+    // 1. plain chunked
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert_eq!(req.body_size, BodySize::Chunked);
+        assert!(!req.is_error());
+    }
+
+    // 2. trailing tab -- the #726 regression case
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: chunked\t\r\n\r\n0\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert_eq!(req.body_size, BodySize::Chunked);
+        assert!(!req.is_error());
+    }
+
+    // 3. surrounding OWS
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding:  chunked \r\n\r\n0\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert_eq!(req.body_size, BodySize::Chunked);
+        assert!(!req.is_error());
+    }
+
+    // 4. "gzip, chunked" -- chunked is the final coding
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert_eq!(req.body_size, BodySize::Chunked);
+        assert!(!req.is_error());
+    }
+
+    // 5. "chunked, gzip" -- chunked is NOT the final coding -> reject
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: chunked, gzip\r\n\r\nabc";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(req.is_error());
+    }
+
+    // 6. "identity" -- not chunked at all -> reject
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: identity\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(req.is_error());
+    }
+
+    // 7. "xchunked" -- false positive under the old suffix-only check -> reject
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: xchunked\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(req.is_error());
+    }
+}
+
+#[test]
+fn transfer_encoding_ows_elides_content_length() {
+    // "Transfer-Encoding: chunked\t" (trailing tab) alongside a
+    // Content-Length must still select chunked framing AND elide the
+    // Content-Length, so only one framing header reaches the backend.
+    const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Content-Length: 3\r\n\
+Transfer-Encoding: chunked\t\r\n\r\n0\r\n\r\n";
+    let mut buffer = vec![0; 4096];
+    let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+    req.storage.write(REQUEST).expect("write");
+    h1::parse(&mut req, &mut h1::NoCallbacks);
+    assert_eq!(req.body_size, BodySize::Chunked);
+    assert!(!req.is_error());
+    for block in &req.blocks {
+        if let Block::Header(header) = block {
+            if let Some(key) = header.key.data_opt(&buffer) {
+                assert_ne!(key, b"Content-Length");
+            }
+        }
+    }
+}
+
+#[test]
 fn malformed_cookies_separator() {
     const REQUEST: &'static [u8] = b"\
 GET /cookies HTTP/1.1\r\n\

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -204,6 +204,90 @@ Transfer-Encoding: chunked\t\r\n\r\n0\r\n\r\n";
 }
 
 #[test]
+fn transfer_encoding_split_header_lines() {
+    // RFC 9110 §5.3: repeated Transfer-Encoding field lines are
+    // equivalent to a single comma-joined value, in the order the lines
+    // appear on the wire. Regression test: rejecting as soon as one
+    // Transfer-Encoding header BLOCK doesn't end in chunked (instead of
+    // waiting for the combined/last value) broke split Transfer-Encoding
+    // whose final line is chunked.
+    let mut buffer = vec![0; 4096];
+
+    // "gzip" then "chunked" on separate lines == "gzip, chunked" as a
+    // single value -> chunked is the final coding -> valid chunked
+    // framing, not an error.
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: gzip\r\n\
+Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert_eq!(req.body_size, BodySize::Chunked);
+        assert!(!req.is_error());
+        assert!(req.is_terminated());
+    }
+
+    // "chunked" then "identity" on separate lines == "chunked, identity"
+    // as a single value -> chunked is NOT the final coding -> reject
+    // (RFC 9112 §6.3), even though the FIRST line alone ends in chunked.
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: chunked\r\n\
+Transfer-Encoding: identity\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(req.is_error());
+    }
+}
+
+#[test]
+fn transfer_encoding_response_non_chunked_final_is_not_an_error() {
+    // RFC 9112 §6.3's "reject a message whose Transfer-Encoding does not
+    // end in chunked" is a REQUEST-only rule: the server cannot ask the
+    // client to retry with a different framing, so an unreliable request
+    // body length must be rejected outright. A RESPONSE with a
+    // Transfer-Encoding that does not end in chunked (e.g. a lone
+    // "gzip") is spec-valid instead: the body is close-delimited (read
+    // until the connection closes) rather than an error.
+    let mut buffer = vec![0; 4096];
+
+    {
+        const RESPONSE: &[u8] = b"\
+HTTP/1.1 200 OK\r\n\
+Transfer-Encoding: gzip\r\n\r\n";
+        let mut resp = Kawa::new(Kind::Response, Buffer::new(SliceBuffer(&mut buffer[..])));
+        resp.storage.write(RESPONSE).expect("write");
+        h1::parse(&mut resp, &mut h1::NoCallbacks);
+        assert!(!resp.is_error());
+        // No Content-Length was present, so the pre-fix reference value
+        // is BodySize::Empty (close-delimited: read until connection
+        // close), not merely "anything other than Chunked".
+        assert_eq!(resp.body_size, BodySize::Empty);
+    }
+
+    // A response whose Transfer-Encoding DOES end in chunked still gets
+    // chunked framing -- the request-only reject rule above must not
+    // suppress genuinely valid chunked responses.
+    {
+        const RESPONSE: &[u8] = b"\
+HTTP/1.1 200 OK\r\n\
+Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+        let mut resp = Kawa::new(Kind::Response, Buffer::new(SliceBuffer(&mut buffer[..])));
+        resp.storage.write(RESPONSE).expect("write");
+        h1::parse(&mut resp, &mut h1::NoCallbacks);
+        assert_eq!(resp.body_size, BodySize::Chunked);
+        assert!(!resp.is_error());
+        assert!(resp.is_terminated());
+    }
+}
+
+#[test]
 fn malformed_cookies_separator() {
     const REQUEST: &'static [u8] = b"\
 GET /cookies HTTP/1.1\r\n\

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -285,6 +285,23 @@ Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
         assert!(!resp.is_error());
         assert!(resp.is_terminated());
     }
+
+    // Regression (the finding): a response whose split Transfer-Encoding lines
+    // are "chunked" then "identity" combines to "chunked, identity" -- chunked
+    // is NOT the final coding, so the body is close-delimited, NOT chunked. The
+    // earlier "chunked" line must not latch chunked framing (the prior fix left
+    // body_size stuck at Chunked here).
+    {
+        const RESPONSE: &[u8] = b"\
+HTTP/1.1 200 OK\r\n\
+Transfer-Encoding: chunked\r\n\
+Transfer-Encoding: identity\r\n\r\n";
+        let mut resp = Kawa::new(Kind::Response, Buffer::new(SliceBuffer(&mut buffer[..])));
+        resp.storage.write(RESPONSE).expect("write");
+        h1::parse(&mut resp, &mut h1::NoCallbacks);
+        assert!(!resp.is_error());
+        assert_eq!(resp.body_size, BodySize::Empty);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Make chunked-framing detection in `process_headers` RFC-correct.

Chunked framing was selected by a suffix-only compare on the raw `Transfer-Encoding` value, with no
OWS trim. Per RFC 9112 §6.1 (chunked must be the final transfer-coding) and RFC 9110 §5.6.3 (OWS),
this selects chunked only when the **final** comma-separated transfer-coding token equals `chunked`
(case-insensitive) after trimming OWS from the value and each token. When a `Transfer-Encoding` is
present but its final coding is not `chunked`, it now raises a parse error instead of leaving the
framing unresolved. Existing behavior (Content-Length elision, the multi-TE / CL+TE warnings) is
preserved when chunked is selected.

Fixes two issues in the old suffix check: values such as `chunked\t` or ` chunked ` were not
recognised as chunked, and `xchunked` false-positived as chunked.

Two small zero-copy helpers (`trim_ows`, `ends_with_chunked_coding`), no new deps.

## Tests (`tests/edge_cases.rs`)

`chunked`, `chunked\t`, ` chunked `, `gzip, chunked` → Chunked; `chunked, gzip`, `identity`,
`xchunked` → parse error; `Content-Length` + `chunked\t` → Chunked with Content-Length elided. All
17 crate tests pass; `clippy --lib` and `fmt --check` clean.

## Notes for reviewers

- `clippy --all-targets -- -D warnings` fails on this branch, but identically on unmodified
  `v0.6.8` (pre-existing test-lint debt: `unused_io_amount`, etc.). `clippy --lib` is clean.
- Headers are processed one block at a time, so a split `Transfer-Encoding: gzip` +
  `Transfer-Encoding: chunked` (two separate lines) is now rejected on the first line, while the
  combined `Transfer-Encoding: gzip, chunked` is accepted — flagging in case you'd prefer to
  coalesce same-name TE headers first. The reject-on-non-chunked-final rule also applies to
  responses (e.g. a close-delimited `Transfer-Encoding: gzip` response is rejected).
