### PR TITLE
fix(h1): exclude surrounding OWS from header field values

### DIFF
--- a/src/protocol/h1/parser/mod.rs
+++ b/src/protocol/h1/parser/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     protocol::{
         h1::parser::primitives::{
             crlf, parse_chunk_header, parse_header, parse_header_or_cookie, parse_request_line,
-            parse_response_line, parse_single_crumb, parse_url,
+            parse_response_line, parse_single_crumb, parse_url, trim_ows,
         },
         utils::compare_no_case,
     },
@@ -50,19 +50,6 @@ fn handle_recovery_error<T: AsBuffer>(
         }
         NomErr::Incomplete(_) => kawa.parsing_phase,
     }
-}
-
-/// Trims leading and trailing optional whitespace (OWS) as defined by
-/// RFC 9110 §5.6.3: space (0x20) and horizontal tab (0x09).
-#[inline]
-fn trim_ows(mut data: &[u8]) -> &[u8] {
-    while let [b' ' | b'\t', rest @ ..] = data {
-        data = rest;
-    }
-    while let [rest @ .., b' ' | b'\t'] = data {
-        data = rest;
-    }
-    data
 }
 
 /// Returns true if the FINAL comma-separated transfer-coding token of a
@@ -173,9 +160,11 @@ fn process_headers<T: AsBuffer>(kawa: &mut Kawa<T>) {
                     BodySize::Chunked => header.elide(),
                 }
             }
-            // Transfer-Encoding header lines are intentionally left in place
-            // (forwarded as received); their combined framing was resolved by
-            // the pre-scan above.
+            // Transfer-Encoding header lines are intentionally left in place;
+            // their combined framing was resolved by the pre-scan above. Their
+            // values carry no leading/trailing OWS (RFC 9112 §5 -- stripped at
+            // parse time), so what is forwarded is the coding we framed on,
+            // never an obfuscated spelling of it.
         }
     }
     if transfer_encoding_present {

--- a/src/protocol/h1/parser/primitives.rs
+++ b/src/protocol/h1/parser/primitives.rs
@@ -233,6 +233,19 @@ pub fn parse_response_line(i: &[u8]) -> IResult<&[u8], (Version, &[u8], u16, &[u
 }
 
 /// parse a HTTP header, including terminating CRLF
+/// Trims leading and trailing optional whitespace (OWS) as defined by
+/// RFC 9110 §5.6.3: space (0x20) and horizontal tab (0x09).
+#[inline]
+pub fn trim_ows(mut data: &[u8]) -> &[u8] {
+    while let [b' ' | b'\t', rest @ ..] = data {
+        data = rest;
+    }
+    while let [rest @ .., b' ' | b'\t'] = data {
+        data = rest;
+    }
+    data
+}
+
 /// if it is a cookie header, nothing is returned and parse_single_crumb should be called
 ///
 /// example: `Content-Length: 42\r\n`
@@ -247,7 +260,7 @@ pub fn parse_header_or_cookie(i: &[u8]) -> IResult<&[u8], Option<(&[u8], &[u8])>
     }
     let (i, val) = achar::take_while_fast(i)?;
     let (i, _) = crlf(i)?;
-    Ok((i, Some((key, val))))
+    Ok((i, Some((key, trim_ows(val)))))
 }
 
 /// parse a HTTP header, including terminating CRLF
@@ -261,7 +274,7 @@ pub fn parse_header(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
     let (i, _) = take_while(AsChar::is_space).parse(i)?;
     let (i, val) = achar::take_while_fast(i)?;
     let (i, _) = crlf(i)?;
-    Ok((i, (key, val)))
+    Ok((i, (key, trim_ows(val))))
 }
 
 /// parse a single crumb from a Cookie header

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -178,6 +178,103 @@ Transfer-Encoding: xchunked\r\n\r\n";
     }
 }
 
+/// Returns the value of the first non-elided header matching `name`.
+fn header_value<'a>(req: &'a Kawa<SliceBuffer<'a>>, name: &[u8]) -> Option<&'a [u8]> {
+    let buf = req.storage.buffer();
+    req.blocks.iter().find_map(|block| match block {
+        Block::Header(header) => {
+            let key = header.key.data_opt(buf)?;
+            if key.eq_ignore_ascii_case(name) {
+                header.val.data_opt(buf)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    })
+}
+
+#[test]
+fn header_value_excludes_surrounding_ows() {
+    // RFC 9112 §5: "A field value does not include leading or trailing
+    // whitespace." Leading OWS was already stripped (the `take_while` after
+    // the colon), but `achar` accepts SP/HTAB, so trailing OWS was swallowed
+    // into the stored value. Two distinct defects followed, both fixed by
+    // trimming the value at parse time:
+    //
+    //   * `Transfer-Encoding: chunked\t` selects chunked framing (the value
+    //     is OWS-trimmed to decide the final coding) yet was FORWARDED
+    //     verbatim. A peer that does not itself trim then sees a coding it
+    //     does not recognise and -- the Content-Length having been elided
+    //     per RFC 9110 §6.3 -- no length either, so it reads the chunked
+    //     body as a pipelined message: a TE.TE desync. Deciding framing on a
+    //     normalized reading while forwarding the un-normalized bytes is the
+    //     gap; forward the coding we actually framed on.
+    //
+    //   * `Content-Length: 5 ` is a legal field value, but `"5 ".parse()`
+    //     returned None and the request was rejected outright.
+    let mut buffer = vec![0; 4096];
+
+    // 1. the forwarded Transfer-Encoding is the coding we framed on
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Transfer-Encoding: chunked\t\r\n\r\n0\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write_all(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert_eq!(req.body_size, BodySize::Chunked);
+        assert!(!req.is_error());
+        assert_eq!(
+            header_value(&req, b"transfer-encoding"),
+            Some(&b"chunked"[..]),
+            "the Transfer-Encoding we framed on must be forwarded canonically, \
+             not as the obfuscated spelling we received"
+        );
+    }
+
+    // 2. trailing OWS no longer rejects a legal Content-Length
+    {
+        const REQUEST: &[u8] = b"\
+POST / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Content-Length: 5 \r\n\r\nHello";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write_all(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(!req.is_error());
+        assert_eq!(req.body_size, BodySize::Length(5));
+    }
+
+    // 3. the rule is general, not Transfer-Encoding specific: leading and
+    //    trailing OWS around any field value are not part of the value.
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+X-Custom: \tvalue \t\r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write_all(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(!req.is_error());
+        assert_eq!(header_value(&req, b"x-custom"), Some(&b"value"[..]));
+    }
+
+    // 4. an all-OWS field value trims to empty rather than to whitespace
+    {
+        const REQUEST: &[u8] = b"\
+GET / HTTP/1.1\r\n\
+Host: example.com\r\n\
+X-Empty: \t \r\n\r\n";
+        let mut req = Kawa::new(Kind::Request, Buffer::new(SliceBuffer(&mut buffer[..])));
+        req.storage.write_all(REQUEST).expect("write");
+        h1::parse(&mut req, &mut h1::NoCallbacks);
+        assert!(!req.is_error());
+        assert_eq!(header_value(&req, b"x-empty"), Some(&b""[..]));
+    }
+}
+
 #[test]
 fn transfer_encoding_ows_elides_content_length() {
     // "Transfer-Encoding: chunked\t" (trailing tab) alongside a


### PR DESCRIPTION
## Problem

RFC 9112 §5: *"A field value does not include leading or trailing whitespace."*

`parse_header` strips **leading** OWS (the `take_while(AsChar::is_space)` after the colon), but `achar` accepts SP (0x20) and HTAB (0x09), so `take_while_fast` swallows **trailing** OWS into the value. Stored field values are therefore not field values. Two unrelated-looking defects fall out of that one asymmetry.

**1. A legal `Content-Length` is rejected.** `Content-Length: 5 ` is valid — the trailing space is not part of the value — but it is stored as `5 `, `parse_to()` returns `None`, and the message is rejected:

```
Content-Length: 5    -> body_size=Length(5)  is_error=false
Content-Length: 5<SP> -> body_size=Empty     is_error=true
                         Error { marker: Headers, kind: Processing {
                           message: "Invalid Content-Length field value" } }
```

**2. `Transfer-Encoding` is framed on one reading and forwarded as another.** `ends_with_chunked_coding` OWS-trims the value to decide the final coding, so `Transfer-Encoding: chunked\t` correctly selects chunked framing — but the field line is then forwarded verbatim, obfuscation intact:

```
Transfer-Encoding: chunked\t -> body_size=Chunked, is_error=false
                                forwarded value: "chunked\t"   <-- not what we framed on
```

Deciding framing on a normalized reading of a value while forwarding the un-normalized bytes is a desync primitive. Since #19 a present `Transfer-Encoding` elides *every* `Content-Length` (RFC 9110 §6.3), so a peer that does not itself trim OWS sees neither a transfer-coding it recognises nor a length — and reads the chunked body as a pipelined message (a TE.TE desync). Normalizing to understand a coding and then forwarding the original spelling is the gap.

## Fix

Trim OWS once, at parse time, for every header value — `parse_header` and `parse_header_or_cookie`. The trim is allocation-free (the result is a subslice of the same buffer).

`trim_ows` moves from `parser/mod.rs` to `parser/primitives.rs`, beside the parsers that now use it, so the whole-value trim and the per-token trim inside `ends_with_chunked_coding` share a single definition rather than drifting apart.

Cookie values are untouched: `parse_header_or_cookie` returns before the value is read, and crumbs go through `parse_single_crumb` (`ck_char`/`cv_char`, a different charset).

## Result

```
Content-Length: 5<SP>        -> body_size=Length(5)  is_error=false   (was: rejected)
Transfer-Encoding: chunked\t -> body_size=Chunked, forwarded "chunked" (was: "chunked\t")
```

What we frame on and what we forward are now the same coding.

## Tests

New `header_value_excludes_surrounding_ows` in `tests/edge_cases.rs` pins the property directly — the existing `transfer_encoding_ows_and_final_coding` asserted `body_size` but never what gets **forwarded**, which is exactly where the bug lived:

1. `Transfer-Encoding: chunked\t` is forwarded as `chunked`
2. `Content-Length: 5 ` frames as `Length(5)` instead of being rejected
3. the rule is general, not TE-specific — `X-Custom: \tvalue \t` stores `value`
4. an all-OWS value trims to empty, not to whitespace

Seen red against the unfixed parser:

```
assertion `left == right` failed: the Transfer-Encoding we framed on must be
forwarded canonically, not as the obfuscated spelling we received
  left:  Some([99,104,117,110,107,101,100, 9])   // "chunked\t"
  right: Some([99,104,117,110,107,101,100])      // "chunked"
```

Full gate on the fix: `cargo test --all-features` (20 tests) exit 0, `cargo clippy --all-targets --all-features` exit 0 / 0 warnings, `cargo fmt --all --check` exit 0. Existing cookie and TE tests unchanged and passing.

## Downstream impact (sozu)

This supersedes the proxy-side workaround in sozu's CL.TE guard (`lib/src/protocol/kawa_h1/editor.rs`), which fails closed on any `Transfer-Encoding` whose **raw** value does not literally end in `chunked` — precisely because kawa forwarded the obfuscated spelling.

Verified by building sozu against this branch via `[patch.crates-io]`: values arrive pre-trimmed, so `chunked\t` reaches the guard as `chunked`, passes it, and is forwarded canonically. Two sozu e2e cases that currently assert `400` (`test_h1_smuggling_te_cl_trailing_tab` case `no-content-length`, and `test_h1_smuggling_auth_bypass`) then see the request handled instead. That is the **correct** end state — `chunked\t` *is* a legal chunked request, and forwarding is now canonical, so rejecting it would reject legal traffic the way `Content-Length: 5 ` was being rejected — but it is a deliberate change of those tests' expectations and should land as its own reviewed sozu change when the pin is bumped. sozu is unaffected until then: `Cargo.lock` pins 0.7.0 exactly.

Needs a 0.7.1 release before sozu can bump.